### PR TITLE
Add gitignore for Apps Script repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,19 @@
+# Google Apps Script files and environment
+.clasp.json
+appsscript.json
+
+# Node dependencies
+node_modules/
+
+# Logs and system files
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+*.log
+
+# OS generated files
+.DS_Store
+Thumbs.db
+
+# IDE files
+.vscode/


### PR DESCRIPTION
## Summary
- add `.gitignore` with common Google Apps Script patterns

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6846c69cb8848333b760d378c2e4debd