### PR TITLE
Add duplicate customer warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ Select **Scanner → Open Scanner Sidebar** from the spreadsheet menu. The sideb
 contains a single input box and three buttons:
 
 - **Scan** – records the parcel as dispatched or prompts to mark it returned.
+- The scan will also warn if another undelivered order has the same customer
+  name or phone number so you can choose whether to dispatch it.
 - **Undo Last Scan** – reverts the most recent scan and adjusts the summary
   sheets.
 - **Cancel Order** – marks an order as "Cancelled by Customer" and attempts to

--- a/ScannerSidebar.html
+++ b/ScannerSidebar.html
@@ -33,6 +33,16 @@
                   .processParcelConfirmReturn(code);
               } else showMessage('⏎ Skipped');
             }
+            else if (res==='confirmDuplicate') {
+              var msg = 'Multiple orders for this customer. Dispatch anyway?';
+              if (confirm(msg)) {
+                google.script.run
+                  .withSuccessHandler(r2=>{
+                    showMessage(r2==='Dispatched'? '✓ Dispatched' : 'ERR:'+r2);
+                  })
+                  .processParcelConfirmDuplicate(code);
+              } else showMessage('⏎ Held');
+            }
             else if (res==='AlreadyReturned') showMessage('⚠️ Already returned');
             else if (res==='NotFound')        showMessage('❌ Not found');
             else showMessage('?? '+res);


### PR DESCRIPTION
## Summary
- detect duplicate pending orders by customer name or phone
- prompt user when duplicate found during scan
- allow dispatch after confirmation
- document the new warning in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6846c8f940f88333a4abc87d3a17cf2c