### PR TITLE
Add manual status corrections

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,6 @@ contains a single input box and four buttons:
   number and attempts to cancel the corresponding order on Shopify.
 - **Cancel by Order #** – enter just the numeric portion of an order number to
   cancel it in the sheet and on Shopify.
-
+- **Set Custom Status** – choose a status like "Dispatched" or "Returned" and optionally select a date to apply it.
 After each action a short message appears at the bottom of the sidebar to confirm
 what happened.

--- a/ScannerSidebar.html
+++ b/ScannerSidebar.html
@@ -1,4 +1,3 @@
- 
 <!DOCTYPE html>
 <html>
   <head>
@@ -6,6 +5,7 @@
     <style>
       #statusMessage { margin-top:8px; font-weight:bold; color:#007500; }
       button { margin-right:4px; }
+      .inline { margin-top:6px; }
     </style>
     <script>
       // show a quick non-blocking message
@@ -68,12 +68,30 @@
         inp.focus();
       }
 
+      function applyStatus() {
+        var code   = document.getElementById('parcelInput').value.trim();
+        var status = document.getElementById('statusInput').value.trim();
+        var date   = document.getElementById('statusDate').value;
+        if (!code || !status) return;
+        google.script.run.withSuccessHandler(res => {
+          var map = {
+            'Updated': '✅ Status updated',
+            'NotFound': '❌ Parcel not found',
+            'MissingHeaders': '⚠️ Check column headers'
+          };
+          showMessage(map[res] || res);
+          resetInput();
+        }).manualSetStatus(code, status, date);
+      }
+
       document.addEventListener('DOMContentLoaded',()=>{
         var inp = document.getElementById('parcelInput');
         inp.focus();
         inp.addEventListener('keyup', e=>{
           if (e.keyCode===13) submitScan();
         });
+        var today = new Date().toISOString().substr(0,10);
+        document.getElementById('statusDate').value = today;
       });
     </script>
   </head>
@@ -83,6 +101,16 @@
   <button onclick="undoScan()">Undo Last Scan</button>
   <button onclick="cancelManual()">Cancel Order</button>
   <button onclick="cancelByOrderNumber()">Cancel by Order #</button>
+  <div class="inline">
+    <input id="statusInput" list="statusList" placeholder="Custom Status">
+    <datalist id="statusList">
+      <option value="Dispatched">
+      <option value="Returned">
+      <option value="Cancelled by Customer">
+    </datalist>
+    <input type="date" id="statusDate">
+    <button onclick="applyStatus()">Set Status</button>
+  </div>
   <div id="statusMessage"></div>
 
   <script>

--- a/code.gs
+++ b/code.gs
@@ -677,3 +677,43 @@ function cancelOrderByNumber(orderNumRaw) {
 
 
 
+/**
+ * Manually set the shipping status and optional date for a parcel.
+ * @param {string} parcelRaw Parcel number.
+ * @param {string} newStatus Status text to set.
+ * @param {string} dateStr   Optional date string YYYY-MM-DD.
+ * @return {string} result code.
+ */
+function manualSetStatus(parcelRaw, newStatus, dateStr) {
+  var parcel = String(parcelRaw).trim().replace(/\s+/g, '');
+  if (!parcel) return 'Empty';
+
+  var ss     = SpreadsheetApp.getActiveSpreadsheet();
+  var sheet  = ss.getSheetByName("Sheet1");
+  var head   = sheet.getRange(1, 1, 1, sheet.getLastColumn()).getValues()[0];
+
+  var parcelCol = head.indexOf("Parcel number") + 1;
+  var statusCol = head.indexOf("Shipping Status") + 1;
+  var dateCol   = head.indexOf("Dispatch Date") + 1;
+
+  if (!parcelCol || !statusCol || !dateCol) return 'MissingHeaders';
+
+  var data     = sheet.getDataRange().getValues();
+  var foundRow = -1;
+  for (var r = 1; r < data.length; r++) {
+    var val = String(data[r][parcelCol - 1]).replace(/\s+/g, '');
+    if (val.toUpperCase() === parcel.toUpperCase()) {
+      foundRow = r + 1;
+      break;
+    }
+  }
+  if (foundRow === -1) return 'NotFound';
+
+  var dateObj = dateStr ? new Date(dateStr) : new Date();
+  dateObj.setHours(0,0,0,0);
+
+  sheet.getRange(foundRow, statusCol).setValue(newStatus);
+  sheet.getRange(foundRow, dateCol).setValue(dateObj);
+
+  return 'Updated';
+}


### PR DESCRIPTION
## Summary
- allow choosing a custom status and date for a parcel
- document the new **Set Custom Status** sidebar action

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6846d58f23048333ae232e6cabbe96fc