### PR TITLE
Fix duplicate warning on blank customer info

### DIFF
--- a/code.gs
+++ b/code.gs
@@ -74,13 +74,17 @@ function processParcelScan(scannedValue) {
   if (nameCol || phoneCol) {
     var custName = nameCol ? rowData[nameCol-1] : '';
     var phone    = phoneCol ? rowData[phoneCol-1] : '';
-    for (var r=1; r<data.length; r++) {
-      if (r===foundRow-1) continue;
-      var status = data[r][statusCol-1];
-      if (status==='Dispatched' || status==='Returned') continue;
-      if ((nameCol && data[r][nameCol-1]===custName) ||
-          (phoneCol && data[r][phoneCol-1]===phone)) {
-        dupFound = true; break;
+    if (custName || phone) { // only check when name or phone is present
+      for (var r=1; r<data.length; r++) {
+        if (r===foundRow-1) continue;
+        var status = data[r][statusCol-1];
+        if (status==='Dispatched' || status==='Returned') continue;
+        if (custName && nameCol && data[r][nameCol-1]===custName) {
+          dupFound = true; break;
+        }
+        if (phone && phoneCol && data[r][phoneCol-1]===phone) {
+          dupFound = true; break;
+        }
       }
     }
   }


### PR DESCRIPTION
## Summary
- prevent duplicate customer warnings when name or phone is blank

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684984dd4e6c833388abb78814f025dc