### PR TITLE
Prevent dispatching cancelled orders

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ contains a single input box and four buttons:
   number and attempts to cancel the corresponding order on Shopify.
 - **Cancel by Order #** – enter just the numeric portion of an order number to
   cancel it in the sheet and on Shopify.
+- Once cancelled by the customer, an order cannot be dispatched.
 - **Set Custom Status** – choose a status like "Dispatched" or "Returned" and optionally select a date to apply it.
 After each action a short message appears at the bottom of the sidebar to confirm
 what happened.

--- a/ScannerSidebar.html
+++ b/ScannerSidebar.html
@@ -43,6 +43,7 @@
                   .processParcelConfirmDuplicate(code);
               } else showMessage('⏎ Held');
             }
+            else if (res==='WasCancelled') showMessage('⚠️ Order was cancelled');
             else if (res==='AlreadyReturned') showMessage('⚠️ Already returned');
             else if (res==='NotFound')        showMessage('❌ Not found');
             else showMessage('?? '+res);
@@ -77,7 +78,8 @@
           var map = {
             'Updated': '✅ Status updated',
             'NotFound': '❌ Parcel not found',
-            'MissingHeaders': '⚠️ Check column headers'
+            'MissingHeaders': '⚠️ Check column headers',
+            'WasCancelled': '⚠️ Order was cancelled'
           };
           showMessage(map[res] || res);
           resetInput();

--- a/code.gs
+++ b/code.gs
@@ -58,6 +58,11 @@ function processParcelScan(scannedValue) {
       oldStatus = statusCol ? rowData[statusCol-1] : '',
       oldDate   = dateCol   ? rowData[dateCol-1] : null;
 
+  // prevent dispatching an order cancelled by the customer
+  if (String(oldStatus).trim() === 'Cancelled by Customer') {
+    return 'WasCancelled';
+  }
+
   // decide
   var actionType, newStatus;
   if (!oldStatus || (oldStatus!=='Dispatched' && oldStatus!=='Returned')) {
@@ -221,6 +226,9 @@ function processParcelConfirmDuplicate(scannedValue) {
   var rowData   = sheet.getRange(foundRow,1,1,sheet.getLastColumn()).getValues()[0],
       oldStatus = statusCol ? rowData[statusCol-1] : '',
       oldDate   = dateCol   ? rowData[dateCol-1] : null;
+    if (String(oldStatus).trim() === "Cancelled by Customer") {
+        return "WasCancelled";
+    }
 
   if (oldStatus==='Dispatched' || oldStatus==='Returned') {
     return oldStatus==='Dispatched' ? 'confirmReturn' : 'AlreadyReturned';
@@ -719,6 +727,10 @@ function manualSetStatus(parcelRaw, newStatus, dateStr) {
   var rowData   = data[foundRow - 1];
   var oldStatus = rowData[statusCol - 1];
   var oldDate   = rowData[dateCol - 1];
+
+  if (String(oldStatus).trim() === 'Cancelled by Customer' && newStatus === 'Dispatched') {
+    return 'WasCancelled';
+  }
 
   var dateObj = dateStr ? new Date(dateStr) : new Date();
   dateObj.setHours(0, 0, 0, 0);


### PR DESCRIPTION
## Summary
- block dispatch if the parcel's status is `Cancelled by Customer`
- show a warning message in the sidebar when attempting to scan a cancelled parcel
- mention in the README that cancelled orders can't be dispatched

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_684d44759ef8833397342db34b850300