### PR TITLE
Enable CSV upload for COD reconciliation

### DIFF
--- a/CodUploadDialog.html
+++ b/CodUploadDialog.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <base target="_top">
+    <style>
+      body { font-family:sans-serif; padding:20px; }
+      #msg { margin-top:10px; }
+    </style>
+    <script>
+      function uploadFile() {
+        var inp = document.getElementById('codFile');
+        var file = inp.files[0];
+        if (!file) { document.getElementById('msg').textContent='Please choose a file.'; return; }
+        var reader = new FileReader();
+        reader.onload = function(e) {
+          var text = e.target.result;
+          google.script.run.withSuccessHandler(function(res){
+            document.getElementById('msg').textContent = res;
+            google.script.host.close();
+          }).uploadCodInvoice(text);
+        };
+        reader.readAsText(file);
+      }
+    </script>
+  </head>
+  <body>
+    <input type="file" id="codFile" accept=".csv" />
+    <button onclick="uploadFile()">Upload</button>
+    <div id="msg"></div>
+  </body>
+</html>

--- a/README.md
+++ b/README.md
@@ -55,13 +55,11 @@ contains a single input box and four buttons:
 
 ## Importing TCS Invoice Data
 
-Create (or clear) a sheet named `TCS Invoice` in the same spreadsheet. If you
-receive an invoice file with columns such as `CompanyName`, `ParcelNo`,
-`ThirdPartyNo`, `BookingDate`, `Consignee`, `Origin`, `Destination`, `Weight`,
-`CODAmount`, `DeliveryCharges`, `PaymentPeriod`, `Status`, `ItemType` and
-`SpecialInstruction`, open that sheet and choose **File → Import** to upload the
-file. The script reads the `ParcelNo`, `CODAmount` and `Status` headers to match
-each parcel and mark whether payment was received.
+Choose **Scanner → Reconcile COD Payments** and upload the invoice CSV when
+prompted. The script will create (or clear) a sheet named `TCS Invoice`, copy the
+file contents there and then cross‑check dispatched orders. It reads the
+`ParcelNo`, `CODAmount` and `Status` headers to mark each parcel in column **N**
+as either "Paid ✅" or "Dispatched – No COD ❌".
 
 ## Dispatch Summary
 

--- a/code.gs
+++ b/code.gs
@@ -8,7 +8,7 @@ function onOpen() {
   SpreadsheetApp.getUi()
     .createMenu('Scanner')
     .addItem('Open Scanner Sidebar', 'openScannerSidebar')
-    .addItem('Reconcile COD Payments', 'reconcileCODPayments')
+    .addItem('Reconcile COD Payments', 'openCodUploadDialog')
     .addSubMenu(SpreadsheetApp.getUi().createMenu('Dispatch Summary')
       .addItem('Last 5 Days', 'showDispatchSummaryLast5')
       .addItem('Last Week', 'showDispatchSummaryWeek')
@@ -827,6 +827,32 @@ function updateDispatchSummarySheet(days) {
 function showDispatchSummaryLast5()  { updateDispatchSummarySheet(5); }
 function showDispatchSummaryWeek()   { updateDispatchSummarySheet(7); }
 function showDispatchSummaryMonth()  { updateDispatchSummarySheet(30); }
+
+/**
+ * Show a dialog to upload the COD invoice CSV.
+ */
+function openCodUploadDialog() {
+  var html = HtmlService.createHtmlOutputFromFile('CodUploadDialog')
+    .setWidth(300).setHeight(150);
+  SpreadsheetApp.getUi().showModalDialog(html, 'Upload COD Invoice');
+}
+
+/**
+ * Receive uploaded CSV text, store it in TCS Invoice sheet and reconcile.
+ *
+ * @param {string} csvText The raw CSV file contents.
+ * @return {string} Confirmation message.
+ */
+function uploadCodInvoice(csvText) {
+  var data = Utilities.parseCsv(csvText);
+  var ss = SpreadsheetApp.getActiveSpreadsheet();
+  var sheet = ss.getSheetByName('TCS Invoice');
+  if (!sheet) sheet = ss.insertSheet('TCS Invoice');
+  sheet.clearContents();
+  sheet.getRange(1, 1, data.length, data[0].length).setValues(data);
+  reconcileCODPayments();
+  return 'Invoice uploaded and reconciled.';
+}
 
 /**
  * Reconcile COD payments from invoice data and mark orders.


### PR DESCRIPTION
## Summary
- allow Reconcile COD Payments to show an upload dialog
- process the uploaded invoice file and reconcile payments automatically
- document the upload workflow

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68548d818b508333b49b5ffca232791e