### PR TITLE
Handle Excel invoices

### DIFF
--- a/CodUploadDialog.html
+++ b/CodUploadDialog.html
@@ -13,18 +13,20 @@
         if (!file) { document.getElementById('msg').textContent='Please choose a file.'; return; }
         var reader = new FileReader();
         reader.onload = function(e) {
-          var text = e.target.result;
           google.script.run.withSuccessHandler(function(res){
             document.getElementById('msg').textContent = res;
             google.script.host.close();
-          }).uploadCodInvoice(text);
+          }).uploadCodInvoice({
+            data: e.target.result,
+            name: file.name
+          });
         };
-        reader.readAsText(file);
+        reader.readAsDataURL(file);
       }
     </script>
   </head>
   <body>
-    <input type="file" id="codFile" accept=".csv" />
+    <input type="file" id="codFile" accept=".csv,.xls,.xlsx" />
     <button onclick="uploadFile()">Upload</button>
     <div id="msg"></div>
   </body>


### PR DESCRIPTION
## Summary
- update the COD upload dialog to send the selected file as base64 and allow Excel formats
- enhance `uploadCodInvoice` to accept base64 or Blob data and read `.csv`, `.xls`, and `.xlsx` files

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68549a44d61c83339e323bd21634b1ed