### PR TITLE
Restore manual COD reconciliation workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,13 +55,11 @@ contains a single input box and four buttons:
 
 ## Importing TCS Invoice Data
 
-Choose **Scanner → Reconcile COD Payments** and upload the invoice CSV when
-prompted. The script copies the file to a sheet named `TCS Invoice`. If the
-sheet already contains a header row, the new file's header is skipped and only
-the remaining rows are appended. Otherwise the sheet is created (or emptied) and
-all rows are inserted. It then cross‑checks dispatched orders. It reads the
-`ParcelNo`, `CODAmount` and `Status` headers to mark each parcel in column
-**N** as either "Paid ✅" or "Dispatched – No COD ❌".
+Copy or import your invoice rows into the `TCS Invoice` sheet. The first row
+should contain the headers `ParcelNo`, `CODAmount` and `Status`. Then choose
+**Scanner → Reconcile COD Payments** to cross‑check dispatched orders.
+The script marks each parcel in column **N** as either "Paid ✅" or
+"Dispatched – No COD ❌".
 
 ## Dispatch Summary
 

--- a/code.gs
+++ b/code.gs
@@ -8,7 +8,7 @@ function onOpen() {
   SpreadsheetApp.getUi()
     .createMenu('Scanner')
     .addItem('Open Scanner Sidebar', 'openScannerSidebar')
-    .addItem('Reconcile COD Payments', 'openCodUploadDialog')
+    .addItem('Reconcile COD Payments', 'reconcileCODPayments')
     .addSubMenu(SpreadsheetApp.getUi().createMenu('Dispatch Summary')
       .addItem('Last 5 Days', 'showDispatchSummaryLast5')
       .addItem('Last Week', 'showDispatchSummaryWeek')


### PR DESCRIPTION
## Summary
- call `reconcileCODPayments` from the menu instead of the upload dialog
- explain manual pasting of invoice data in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68549fef934c8333bab96d7b8326b8d1