### PR TITLE
Update COD reconciliation logic

### DIFF
--- a/code.gs
+++ b/code.gs
@@ -933,13 +933,17 @@ function reconcileCODPayments() {
   for (let r = 1; r < orderData.length; r++) {
     const shippingStatus = String(orderData[r][statusCol]).toLowerCase();
     const rawParcel = String(orderData[r][parcelCol] || '').replace(/\s+/g, '').trim();
+    const rec = invoiceMap[rawParcel];
+    const statusCell = orderSheet.getRange(r + 1, statusCol + 1);
     if (shippingStatus === 'dispatched') {
       let result = 'Dispatched – No COD ❌';
-      const rec = invoiceMap[rawParcel];
       if (rec && rec.status === 'delivered' && rec.cod && parseFloat(rec.cod) > 0) {
         result = 'Paid ✅';
       }
       orderSheet.getRange(r + 1, resultCol + 1).setValue(result);
+    } else if (!shippingStatus && rec && rec.status === 'delivered' && rec.cod && parseFloat(rec.cod) > 0) {
+      statusCell.setValue('Delivered');
+      orderSheet.getRange(r + 1, resultCol + 1).setValue('Paid ✅');
     }
   }
 


### PR DESCRIPTION
## Summary
- update `reconcileCODPayments` to mark orders as delivered when COD payments show delivered status but the shipping column is blank

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6854a45cc2ac8333b8da1086cf6ac892