### PR TITLE
Enable custom date ranges for dispatch summary

### DIFF
--- a/DispatchSummaryDialog.html
+++ b/DispatchSummaryDialog.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <base target="_top">
+    <style>
+      body { font-family:sans-serif; padding:20px; }
+      #msg { margin-top:10px; }
+    </style>
+    <script>
+      function generate() {
+        var start = document.getElementById('startDate').value;
+        var end = document.getElementById('endDate').value;
+        if (!start || !end) return;
+        google.script.run.withSuccessHandler(function(res){
+          document.getElementById('msg').textContent = res;
+          google.script.host.close();
+        }).createDispatchSummaryCustom(start, end);
+      }
+      document.addEventListener('DOMContentLoaded', function(){
+        var today = new Date();
+        var start = new Date(today.getTime() - 7*24*60*60*1000);
+        document.getElementById('startDate').value = start.toISOString().substr(0,10);
+        document.getElementById('endDate').value = today.toISOString().substr(0,10);
+      });
+    </script>
+  </head>
+  <body>
+    <label>Start date: <input type="date" id="startDate"></label><br>
+    <label>End date: <input type="date" id="endDate"></label><br>
+    <button onclick="generate()">Generate</button>
+    <div id="msg"></div>
+  </body>
+</html>

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ light green.
 
 ## Dispatch Summary
 
-The **Scanner** menu also provides a **Dispatch Summary** submenu. Choose one of the preset ranges (Last 5 Days, Last Week or Last Month) to generate a sheet named **Dispatch Summary** with total quantities grouped by product for that period.
+The **Scanner** menu also provides a **Dispatch Summary** submenu. Choose one of the preset ranges (Last 5 Days, Last Week or Last Month) or pick **Custom Range…** to enter your own start and end dates. A sheet named **Dispatch Summary** will be generated with total quantities grouped by product for the selected period.
 
 ## Local Rider Orders
 


### PR DESCRIPTION
## Summary
- allow selecting a custom date range for the Dispatch Summary
- add new dialog for custom date input
- document the new option in the README

## Testing
- `node --check code.gs`

------
https://chatgpt.com/codex/tasks/task_e_685aa5f40ec88333ae1374c44e5703d4