### PR TITLE
Fix scanning functions for undefined input

### DIFF
--- a/code.gs
+++ b/code.gs
@@ -372,7 +372,7 @@ function onEdit(e) {
  * First-time scan handler: marks Dispatched or signals confirmReturn.
  */
 function processParcelScan(scannedValue) {
-  scannedValue = scannedValue.trim().replace(/\s+/g, '');
+  scannedValue = String(scannedValue || '').trim().replace(/\s+/g, '');
   if (!scannedValue) return 'Empty';
 
   var ss      = SpreadsheetApp.getActiveSpreadsheet(),
@@ -481,7 +481,7 @@ function processParcelScan(scannedValue) {
  * After confirm, mark Returned.
  */
 function processParcelConfirmReturn(scannedValue) {
-  scannedValue = scannedValue.trim().replace(/\s+/g,'');
+  scannedValue = String(scannedValue || '').trim().replace(/\s+/g,'');
   if (!scannedValue) return 'Empty';
 
   var ss      = SpreadsheetApp.getActiveSpreadsheet(),
@@ -551,7 +551,7 @@ function processParcelConfirmReturn(scannedValue) {
  * After customer duplicate warning, mark Dispatched.
  */
 function processParcelConfirmDuplicate(scannedValue) {
-  scannedValue = scannedValue.trim().replace(/\s+/g,'');
+  scannedValue = String(scannedValue || '').trim().replace(/\s+/g,'');
   if (!scannedValue) return 'Empty';
 
   var ss      = SpreadsheetApp.getActiveSpreadsheet(),
@@ -1093,7 +1093,7 @@ function findOrderIdByName(orderName) {
  * Updates column G to "Cancelled by Customer" and cancels on Shopify.
  */
 function cancelOrderByCustomer(parcelNumberRaw) {
-  var parcelNumber = parcelNumberRaw.trim().replace(/\s+/g, '');
+  var parcelNumber = String(parcelNumberRaw || '').trim().replace(/\s+/g, '');
   if (!parcelNumber) return 'Empty';
 
   var ss     = SpreadsheetApp.getActiveSpreadsheet();


### PR DESCRIPTION
## Summary
- prevent runtime errors when scanned values are undefined
- guard against undefined input when cancelling orders by parcel number

## Testing
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_68821b861c5083339aae87eaa777257c