### PR TITLE
Fix confirm handler column references

### DIFF
--- a/code.gs
+++ b/code.gs
@@ -493,7 +493,9 @@ function processParcelConfirmReturn(scannedValue) {
       dateCol    = headers.indexOf("Dispatch Date")+1,
       productCol = headers.indexOf("Product name")+1,
       qtyCol     = headers.indexOf("Quantity")+1,
-      amountCol  = headers.indexOf("Amount")+1;
+      amountCol  = headers.indexOf("Amount")+1,
+      nameCol    = headers.indexOf("Customer Name")+1,
+      phoneCol   = headers.indexOf("Phone Number")+1,
       orderCol   = headers.indexOf("Order Number")+1;
 
   if (!parcelCol) return 'ParcelColNotFound';
@@ -563,7 +565,9 @@ function processParcelConfirmDuplicate(scannedValue) {
       dateCol    = headers.indexOf("Dispatch Date")+1,
       productCol = headers.indexOf("Product name")+1,
       qtyCol     = headers.indexOf("Quantity")+1,
-      amountCol  = headers.indexOf("Amount")+1;
+      amountCol  = headers.indexOf("Amount")+1,
+      nameCol    = headers.indexOf("Customer Name")+1,
+      phoneCol   = headers.indexOf("Phone Number")+1;
 
   if (!parcelCol) return 'ParcelColNotFound';
 


### PR DESCRIPTION
## Summary
- fix variable declarations in `processParcelConfirmReturn`
- fix variable declarations in `processParcelConfirmDuplicate`

## Testing
- `node -e "const fs=require('fs');const code=fs.readFileSync('code.gs','utf8');try{new Function(code);console.log('OK');}catch(e){console.error(e.message);}"`

------
https://chatgpt.com/codex/tasks/task_e_68821f8ca7c48333a6b93ca27e1cf29c