### PR TITLE
Reduce scan UI lag

### DIFF
--- a/ScannerSidebar.html
+++ b/ScannerSidebar.html
@@ -12,7 +12,8 @@
       function showMessage(msg) {
         var div = document.getElementById('statusMessage');
         div.textContent = msg;
-        setTimeout(()=> div.textContent = '', 1500);
+        // clear the message quickly so the next scan isn't delayed
+        setTimeout(() => div.textContent = '', 500);
       }
 
       // scan handler
@@ -25,14 +26,16 @@
         document.getElementById('statusMessage').textContent = 'Processing…';
         resetInput();
 
-        google.script.run
-          .withSuccessHandler(res=>{
+        // defer Apps Script call so the UI updates before processing
+        setTimeout(() => {
+          google.script.run
+          .withSuccessHandler(res => {
             if (res==='Dispatched')       showMessage('✓ Dispatched');
             else if (res==='confirmReturn') {
               // confirm before return
               if (confirm('Marked Dispatched — mark as Returned instead?')) {
                 google.script.run
-                  .withSuccessHandler(r2=>{
+                  .withSuccessHandler(r2 => {
                     showMessage(r2==='Returned'? '↺ Returned' : 'ERR:'+r2);
                   })
                   .processParcelConfirmReturn(code);
@@ -42,7 +45,7 @@
               var msg = 'Multiple orders for this customer. Dispatch anyway?';
               if (confirm(msg)) {
                 google.script.run
-                  .withSuccessHandler(r2=>{
+                  .withSuccessHandler(r2 => {
                     showMessage(r2==='Dispatched'? '✓ Dispatched' : 'ERR:'+r2);
                   })
                   .processParcelConfirmDuplicate(code);
@@ -54,6 +57,7 @@
             else showMessage('?? '+res);
           })
           .processParcelScan(code);
+        }, 0);
       }
 
       // undo handler


### PR DESCRIPTION
## Summary
- Clear status messages quickly for faster consecutive scans
- Defer Apps Script processing so input clears immediately

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689322c3ffa88333809ee65a2929f45a