### PR TITLE
Improve scan feedback and speed

### DIFF
--- a/ScannerSidebar.html
+++ b/ScannerSidebar.html
@@ -21,20 +21,24 @@
         const code = inp.value.trim();
         if (!code) return;
 
-        resetInput();
-        showMessage('Processing…', 100);
+        showMessage('Processing…', 0);
 
         google.script.run
           .withSuccessHandler(res => {
-            if (res==='Dispatched')       showMessage('✓ Dispatched');
+            if (res==='Dispatched')       { showMessage('✓ Dispatched'); resetInput(); }
             else if (res==='confirmReturn') {
               if (confirm('Marked Dispatched — mark as Returned instead?')) {
                 google.script.run
                   .withSuccessHandler(r2 => {
                     showMessage(r2==='Returned'? '↺ Returned' : 'ERR:'+r2);
+                    resetInput();
                   })
+                  .withFailureHandler(err => showMessage('ERR:'+err.message))
                   .processParcelConfirmReturn(code);
-              } else showMessage('⏎ Skipped');
+              } else {
+                showMessage('⏎ Skipped');
+                resetInput();
+              }
             }
             else if (res==='confirmDuplicate') {
               const msg = 'Multiple orders for this customer. Dispatch anyway?';
@@ -42,14 +46,22 @@
                 google.script.run
                   .withSuccessHandler(r2 => {
                     showMessage(r2==='Dispatched'? '✓ Dispatched' : 'ERR:'+r2);
+                    resetInput();
                   })
+                  .withFailureHandler(err => showMessage('ERR:'+err.message))
                   .processParcelConfirmDuplicate(code);
-              } else showMessage('⏎ Held');
+              } else {
+                showMessage('⏎ Held');
+                resetInput();
+              }
             }
-            else if (res==='WasCancelled') showMessage('⚠️ Order was cancelled');
-            else if (res==='AlreadyReturned') showMessage('⚠️ Already returned');
-            else if (res==='NotFound')        showMessage('❌ Not found');
-            else showMessage('?? '+res);
+            else if (res==='WasCancelled') { showMessage('⚠️ Order was cancelled'); resetInput(); }
+            else if (res==='AlreadyReturned') { showMessage('⚠️ Already returned'); resetInput(); }
+            else if (res==='NotFound')        { showMessage('❌ Not found'); resetInput(); }
+            else { showMessage('?? '+res); resetInput(); }
+          })
+          .withFailureHandler(err => {
+            showMessage('ERR: '+err.message);
           })
           .processParcelScan(code);
       }
@@ -125,18 +137,21 @@
 
       if (!confirm("Are you sure this order was cancelled by customer?")) return;
 
-      google.script.run.withSuccessHandler(res => {
-        const map = {
-          'Cancelled': '✅ Cancelled & synced to Shopify',
-          'TooLate':   '⚠️ Already dispatched/returned',
-          'NotFound':  '❌ Parcel not found',
-          'OrderNotFoundOnShopify': '🛑 Shopify order not found',
-          'ShopifyFail': '❌ Failed to cancel on Shopify',
-          'MissingHeaders': '⚠️ Check column headers'
-        };
-        showMessage(map[res] || res);
-        resetInput();
-      }).cancelOrderByCustomer(code);
+      google.script.run
+        .withSuccessHandler(res => {
+          const map = {
+            'Cancelled': '✅ Cancelled & synced to Shopify',
+            'TooLate':   '⚠️ Already dispatched/returned',
+            'NotFound':  '❌ Parcel not found',
+            'OrderNotFoundOnShopify': '🛑 Shopify order not found',
+            'ShopifyFail': '❌ Failed to cancel on Shopify',
+            'MissingHeaders': '⚠️ Check column headers'
+          };
+          showMessage(map[res] || res);
+          resetInput();
+        })
+        .withFailureHandler(err => showMessage('ERR:'+err.message))
+        .cancelOrderByCustomer(code);
     }
 
     function cancelByOrderNumber() {
@@ -145,18 +160,21 @@
 
       if (!confirm("Are you sure this order was cancelled by customer?")) return;
 
-      google.script.run.withSuccessHandler(res => {
-        const map = {
-          'Cancelled': '✅ Cancelled & synced to Shopify',
-          'TooLate':   '⚠️ Already dispatched/returned',
-          'NotFound':  '❌ Order not found',
-          'OrderNotFoundOnShopify': '🛑 Shopify order not found',
-          'ShopifyFail': '❌ Failed to cancel on Shopify',
-          'MissingHeaders': '⚠️ Check column headers'
-        };
-        showMessage(map[res] || res);
-        resetInput();
-      }).cancelOrderByNumber(code);
+      google.script.run
+        .withSuccessHandler(res => {
+          const map = {
+            'Cancelled': '✅ Cancelled & synced to Shopify',
+            'TooLate':   '⚠️ Already dispatched/returned',
+            'NotFound':  '❌ Order not found',
+            'OrderNotFoundOnShopify': '🛑 Shopify order not found',
+            'ShopifyFail': '❌ Failed to cancel on Shopify',
+            'MissingHeaders': '⚠️ Check column headers'
+          };
+          showMessage(map[res] || res);
+          resetInput();
+        })
+        .withFailureHandler(err => showMessage('ERR:'+err.message))
+        .cancelOrderByNumber(code);
     }
   </script>
 </body>

--- a/code.gs
+++ b/code.gs
@@ -469,12 +469,14 @@ function processParcelScan(scannedValue) {
   if (dupFound) return 'confirmDuplicate';
 
   // write new
-  sheet.getRange(foundRow,statusCol).setValue(newStatus);
+  var now = new Date(),
+      todayMid = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+  sheet.getRangeList([
+    sheet.getRange(foundRow, statusCol).getA1Notation(),
+    sheet.getRange(foundRow, dateCol).getA1Notation()
+  ]).setValues([[newStatus], [todayMid]]);
   removeFromCustomerIndex(foundRow, nameCol ? rowData[nameCol-1] : '',
                          phoneCol ? rowData[phoneCol-1] : '');
-  var now = new Date(),
-      todayMid = new Date(now.getFullYear(),now.getMonth(),now.getDate());
-  sheet.getRange(foundRow,dateCol).setValue(todayMid);
 
   // parse products & qty
   var products   = String(rowData[productCol-1]).split('\n').map(s=>s.trim()).filter(Boolean),
@@ -534,12 +536,14 @@ function processParcelConfirmReturn(scannedValue) {
       oldDate   = rowData[dateCol-1];
 
   // write Returned
-  sheet.getRange(foundRow,statusCol).setValue('Returned');
+  var now = new Date(),
+      todayMid = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+  sheet.getRangeList([
+    sheet.getRange(foundRow, statusCol).getA1Notation(),
+    sheet.getRange(foundRow, dateCol).getA1Notation()
+  ]).setValues([['Returned'], [todayMid]]);
   removeFromCustomerIndex(foundRow, nameCol ? rowData[nameCol-1] : '',
                          phoneCol ? rowData[phoneCol-1] : '');
-  var now = new Date(),
-      todayMid = new Date(now.getFullYear(),now.getMonth(),now.getDate());
-  sheet.getRange(foundRow,dateCol).setValue(todayMid);
 
   // parse
   var products   = String(rowData[productCol-1]).split('\n').map(s=>s.trim()).filter(Boolean),
@@ -610,11 +614,13 @@ function processParcelConfirmDuplicate(scannedValue) {
     return oldStatus==='Dispatched' ? 'confirmReturn' : 'AlreadyReturned';
   }
 
-  sheet.getRange(foundRow,statusCol).setValue('Dispatched');
+  var now = new Date(), todayMid = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+  sheet.getRangeList([
+    sheet.getRange(foundRow, statusCol).getA1Notation(),
+    sheet.getRange(foundRow, dateCol).getA1Notation()
+  ]).setValues([['Dispatched'], [todayMid]]);
   removeFromCustomerIndex(foundRow, nameCol ? rowData[nameCol-1] : '',
                          phoneCol ? rowData[phoneCol-1] : '');
-  var now = new Date(), todayMid = new Date(now.getFullYear(),now.getMonth(),now.getDate());
-  sheet.getRange(foundRow,dateCol).setValue(todayMid);
 
   var products   = String(rowData[productCol-1]).split('\n').map(s=>s.trim()).filter(Boolean),
       quantities = String(rowData[qtyCol-1]).split('\n').map(s=>s.trim()).filter(Boolean),


### PR DESCRIPTION
## Summary
- keep scanned parcel code visible until processing finishes and show errors if backend fails
- batch status and date updates into single calls for faster scans

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68933ce4c5e483338f0195c55b5b5d72