### PR TITLE
Prevent overriding manual paid statuses during reconciliation

### DIFF
--- a/code.gs
+++ b/code.gs
@@ -1534,6 +1534,9 @@ function reconcileCODPayments() {
       }
     }
     if (shippingStatus === 'dispatched') {
+      if (currentResult === 'Paid ✅') {
+        continue;
+      }
       let result = 'Dispatched – No COD ❌';
       if (rec && rec.status === 'delivered' && rec.cod && rec.cod > 0) {
         result = 'Paid ✅';


### PR DESCRIPTION
## Summary
- avoid overwriting manually marked `Paid ✅` parcels during reconciliation by skipping result updates when the status is already set

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_690b9bd5df8083339f16058ee98210ac